### PR TITLE
chore: remove dev API key fallback and add secrets scan CI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,15 @@
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_SERVICE_KEY=your-service-role-key
+
+# Used by the psql migration runner (libpq format).
+# Formato libpq, usado pelo psql que aplica as migrations.
 SUPABASE_DB_URL=postgresql://postgres:password@db.your-project.supabase.co:5432/postgres
+
+# Used by the forward-api-java Spring Boot container (JDBC format).
+# Formato JDBC, usado pelo Spring Boot do forward-api-java.
+SUPABASE_JDBC_URL=jdbc:postgresql://aws-1-sa-east-1.pooler.supabase.com:6543/postgres?sslmode=require
+SUPABASE_DB_USER=postgres.your-project-ref
+SUPABASE_DB_PASSWORD=your-db-password
+
+SUPABASE_JWKS_URL=https://your-project.supabase.co/auth/v1/keys
+INTERNAL_API_KEY=<your-internal-api-key>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  secrets:
+    name: Secrets scan
+    uses: fwd-ford/.github/.github/workflows/secrets-scan.yml@main

--- a/docker/docker-compose.supabase.yml
+++ b/docker/docker-compose.supabase.yml
@@ -15,7 +15,7 @@ services:
       DATABASE_USER: ${SUPABASE_DB_USER}
       DATABASE_PASSWORD: ${SUPABASE_DB_PASSWORD}
       SUPABASE_JWKS_URL: ${SUPABASE_JWKS_URL}
-      INTERNAL_API_KEY: ${INTERNAL_API_KEY:-forward-internal-dev-key-2026}
+      INTERNAL_API_KEY: ${INTERNAL_API_KEY:?INTERNAL_API_KEY must be set}
       ALLOWED_ORIGINS: http://localhost:3000,http://localhost:5173,http://localhost:8081,http://127.0.0.1:8081
       RATE_LIMIT_MAX: "60"
       RATE_LIMIT_WINDOW: 1m


### PR DESCRIPTION
## Summary

- `docker/docker-compose.supabase.yml`: removed the `forward-internal-dev-key-2026` fallback. Now uses `${INTERNAL_API_KEY:?INTERNAL_API_KEY must be set}` so the container refuses to boot without an explicit key.
- `.env.example`: replaced the dev key value with `<your-internal-api-key>` placeholder.
- `.github/workflows/ci.yml`: calls `fwd-ford/.github/.github/workflows/secrets-scan.yml@main` (gitleaks v8.18.4) on push and PR.

## Why

The repo went public, so the dev key (`forward-internal-dev-key-2026`) — visible in 4 files across the org — was effectively a free credential for anyone scraping GitHub. Production was already using a different rotated key (set as Fly secret), so this PR just closes the loop by making it impossible to "accidentally use the dev default" again.

This addresses the Cybersecurity rubric item 3 ("Proteção API → credenciais").

## Test plan

- [ ] CI runs and `Secrets scan` job passes
- [ ] `docker compose up` without `INTERNAL_API_KEY` set fails with clear error message
- [ ] `docker compose up` with `INTERNAL_API_KEY` set boots normally

## Related

- forward-api-java#11 (rotate the production key — already done as Fly secret)