### PR TITLE
Adding a new migration

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -30,6 +30,7 @@ services:
     environment:
       ENV: development
       PORT: "8080"
+      INTERNAL_API_KEY: ${INTERNAL_API_KEY}
       LOG_LEVEL: INFO
       DATABASE_URL: jdbc:postgresql://postgres:5432/forward?sslmode=disable
       DATABASE_USER: forward
@@ -38,6 +39,7 @@ services:
       RATE_LIMIT_MAX: "60"
       RATE_LIMIT_WINDOW: 1m
       MAX_BODY_BYTES: "1048576"
+      SUPABASE_JWKS_URL: ${SUPABASE_JWKS_URL:-}
     ports:
       - "18080:8080"
 

--- a/supabase/migrations/012_add_service_event_fields.sql
+++ b/supabase/migrations/012_add_service_event_fields.sql
@@ -4,16 +4,22 @@
 -- originated the event (e.g. dealer_app, n8n, manual).
 
 ALTER TABLE service_orders
-    ADD COLUMN maintenance_number INTEGER NOT NULL DEFAULT 0,
-    ADD COLUMN main_source        TEXT    NOT NULL DEFAULT 'legacy';
+    ADD COLUMN IF NOT EXISTS maintenance_number INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS main_source        TEXT    NOT NULL DEFAULT 'legacy';
 
 ALTER TABLE service_orders
     ALTER COLUMN maintenance_number DROP DEFAULT,
     ALTER COLUMN main_source        DROP DEFAULT;
 
+ALTER TABLE service_orders DROP CONSTRAINT IF EXISTS service_orders_maintenance_number_non_negative;
 ALTER TABLE service_orders
     ADD CONSTRAINT service_orders_maintenance_number_non_negative
         CHECK (maintenance_number >= 0);
+
+ALTER TABLE service_orders DROP CONSTRAINT IF EXISTS service_orders_main_source_allowed;
+ALTER TABLE service_orders
+    ADD CONSTRAINT service_orders_main_source_allowed
+        CHECK (main_source IN ('dealer_app', 'n8n', 'manual', 'legacy'));
 
 CREATE INDEX IF NOT EXISTS idx_service_orders_main_source ON service_orders (main_source);
 

--- a/supabase/migrations/012_add_service_event_fields.sql
+++ b/supabase/migrations/012_add_service_event_fields.sql
@@ -1,0 +1,21 @@
+-- Migration: 012_add_service_event_fields
+-- Adds maintenance_number and main_source to service_orders to capture the
+-- dealer-submitted scheduled maintenance sequence and the channel that
+-- originated the event (e.g. dealer_app, n8n, manual).
+
+ALTER TABLE service_orders
+    ADD COLUMN maintenance_number INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN main_source        TEXT    NOT NULL DEFAULT 'legacy';
+
+ALTER TABLE service_orders
+    ALTER COLUMN maintenance_number DROP DEFAULT,
+    ALTER COLUMN main_source        DROP DEFAULT;
+
+ALTER TABLE service_orders
+    ADD CONSTRAINT service_orders_maintenance_number_non_negative
+        CHECK (maintenance_number >= 0);
+
+CREATE INDEX IF NOT EXISTS idx_service_orders_main_source ON service_orders (main_source);
+
+COMMENT ON COLUMN service_orders.maintenance_number IS 'Scheduled maintenance sequence number (e.g. 1st, 2nd, 3rd revision).';
+COMMENT ON COLUMN service_orders.main_source        IS 'Channel that originated the event (e.g. dealer_app, n8n, manual).';


### PR DESCRIPTION
## O que essa PR faz

Adiciona a migration `012_add_service_event_fields.sql` que estende `service_orders` com dois campos para rastrear eventos de serviço:

- `maintenance_number INTEGER NOT NULL` — número sequencial da revisão programada (1ª, 2ª, 3ª…), com check `>= 0`.
- `main_source TEXT NOT NULL` — canal originador do evento (`dealer_app`, `n8n`, `manual`, etc.), com índice `idx_service_orders_main_source` para filtros por canal.

Também expõe duas variáveis de ambiente novas no serviço do `docker-compose.yml`: `INTERNAL_API_KEY` e `SUPABASE_JWKS_URL` (opcional, default vazio).

**Pontos não-óbvios:**
- A migration usa o padrão `ADD COLUMN NOT NULL DEFAULT … → DROP DEFAULT` para preencher linhas existentes (`maintenance_number = 0`, `main_source = 'legacy'`) e depois remover o default. **Após esta PR, todo `INSERT` em `service_orders` precisa fornecer explicitamente esses dois campos** — code paths que inserem na tabela devem ser atualizados em conjunto.
- `INTERNAL_API_KEY` passou a ser repassado do ambiente para o container; precisa estar definido no `.env` / secrets do CI antes do próximo deploy, senão sobe vazio.

## Issue relacionada

<!-- Closes SOA-2 -->

## Como testei

- [ ] Build local passou
- [ ] Testes unitários passam
- [ ] Testei manualmente o caminho golden
- [ ] Não introduzi regressões em outras features

## Checklist

- [ ] Código segue o estilo do repo
- [ ] Commits seguem conventional commits (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`)
- [ ] Atualizei docs/README se a interface mudou
- [ ] Sem segredos hardcoded
- [ ] Cobertura: testes adicionados se faz sentido

## Screenshots / Evidências

<!-- Opcional: prints, logs, gifs. -->

## Notas pro reviewer

- Confirmar se o backfill `main_source = 'legacy'` é o rótulo correto para registros pré-existentes, ou se deveria ser outro valor (`unknown`, `migration`, etc.).
- O índice em `main_source` assume cardinalidade baixa (poucos canais distintos). Se a expectativa for muitos valores únicos, talvez não compense.
- Variáveis novas no compose: garantir que `INTERNAL_API_KEY` esteja no `.env.example` e documentada — não vi atualização desses arquivos no diff.
