### PR TITLE
feat(lgpd): retention policy migration 013 + cron + BACKUP_RESTORE runbook

### DIFF
--- a/BACKUP_RESTORE.md
+++ b/BACKUP_RESTORE.md
@@ -1,0 +1,163 @@
+# Backup and restore — ForwardService data layer
+
+Estratégia de backup, restore e verificação para o banco Postgres do
+ForwardService (Supabase, projeto `ysewoopjgdpvnkfhffgy`). Suplementa o
+[SECURITY.md](SECURITY.md) — esta é a contrapartida operacional dos riscos
+identificados na seção STRIDE.
+
+## 1. Resumo executivo
+
+| Item | Valor | Fonte |
+| ---- | ----- | ----- |
+| Backup automático | Diário, completo | Supabase managed (Pro plan) |
+| Point-in-Time Recovery (PITR) | 7 dias (free) / 30 dias (Pro) | Supabase |
+| Backup manual (pré-deploy) | `pg_dump` para storage Supabase | Operador |
+| RPO (Recovery Point Objective) | ≤ 24h em desastre completo | Estratégia diária |
+| RTO (Recovery Time Objective) | ≤ 2h para restauração full | Supabase dashboard |
+| Frequência de teste de restore | Mensal, em projeto staging | Runbook abaixo |
+
+## 2. O que está protegido
+
+| Camada | Mecanismo | Quem opera |
+| ------ | --------- | ---------- |
+| Schema + dados | Supabase managed daily backup | Supabase (automático) |
+| Migrations SQL | Git (`supabase/migrations/`) | Time, via PR |
+| Seed data | Git (`supabase/seed/`) | Time, via PR |
+| Edge Functions | Git (`supabase/functions/`) + deploy log | Time |
+| Secrets | Fly.io secrets + GitHub Actions secrets | Operadores nomeados |
+| Audit log | Replicado junto com backup do DB | Supabase |
+
+O que **não** está protegido por esta estratégia (intencionalmente):
+
+- Dados em `.env` local (são placeholders, source-of-truth está nos secrets).
+- Logs de aplicação (efêmeros; Fly.io retém 7 dias por padrão).
+- Métricas de instrumentação (não há ainda; ver risco R-05 em SECURITY.md).
+
+## 3. Backup automático (Supabase)
+
+Configurado por padrão pela Supabase para projetos Pro:
+
+- Backup full diário entre 02:00–04:00 UTC.
+- Retenção: 7 dias (plano free) ou 30 dias (Pro).
+- Localização: AWS S3 em `sa-east-1` (mesma região do DB).
+- Encryption: AES-256 at rest, TLS em trânsito.
+
+Verificar status:
+
+```text
+Supabase Dashboard > Database > Backups
+```
+
+A página lista os backups disponíveis, timestamp e tamanho. Falhas geram
+e-mail automático ao billing owner do projeto.
+
+## 4. Backup manual (pré-deploy de risco)
+
+Use antes de aplicar migrations destrutivas ou para snapshot de demo:
+
+```bash
+# Pré-requisitos: psql 16 + supabase CLI logado
+export PGPASSWORD="$(supabase secrets get DB_PASSWORD --project-ref ysewoopjgdpvnkfhffgy)"
+
+pg_dump \
+    --host=db.ysewoopjgdpvnkfhffgy.supabase.co \
+    --port=5432 \
+    --username=postgres \
+    --format=custom \
+    --no-owner --no-privileges \
+    --file="backup-$(date +%Y%m%d-%H%M%S).dump" \
+    postgres
+
+# Move para storage seguro (NUNCA commitar):
+mv backup-*.dump ~/Documents/Ford/backups/
+```
+
+Verificar conteúdo do dump sem restaurar:
+
+```bash
+pg_restore --list backup-20260524-220000.dump | head -40
+```
+
+## 5. Restore — PITR (recomendado para incidentes recentes)
+
+Para reverter para um ponto específico nos últimos 7/30 dias:
+
+```text
+Supabase Dashboard > Database > Backups > Point-in-Time Recovery
+  1. Selecione o timestamp alvo (UTC).
+  2. Confirme criação de um NOVO projeto (não sobrescreve o atual).
+  3. Aguarde ~30–60 min (depende do tamanho do DB).
+  4. Quando ready, validar dados no projeto restaurado.
+  5. Migrar tráfego: atualizar SUPABASE_URL nos secrets do Fly + mobile.
+```
+
+Importante: PITR **cria um novo projeto** com novas chaves. Plano de troca de
+endpoints deve ser comunicado a todos os clientes (mobile via OTA update,
+N8N via dashboard). Estimar RTO total: 2h.
+
+## 6. Restore — dump manual (incidentes antigos ou cross-environment)
+
+Para restaurar um `.dump` em projeto vazio (ex: staging ou novo prod):
+
+```bash
+# 1) Crie um projeto Supabase novo, anote a connection string.
+# 2) Aplique extensions e roles base (Supabase já faz no provisioning).
+# 3) Restore:
+
+pg_restore \
+    --host=db.<NEW_PROJECT>.supabase.co \
+    --port=5432 \
+    --username=postgres \
+    --dbname=postgres \
+    --no-owner --no-privileges \
+    --verbose \
+    backup-20260524-220000.dump
+
+# 4) Re-apply RLS policies (migration 010) se vieram desabilitadas:
+supabase db push --linked --project-ref <NEW_PROJECT>
+
+# 5) Re-schedule pg_cron jobs (migration 013 + scripts/lgpd-retention-cron.sql).
+
+# 6) Sanity-check:
+psql ... -c "SELECT COUNT(*) FROM customers WHERE full_name = '[ANONYMIZED]';"
+psql ... -c "SELECT MAX(created_at) FROM audit_log;"
+```
+
+## 7. Teste mensal de restore (runbook)
+
+Executar primeiro sábado de cada mês, registrado em `audit_log`:
+
+1. Criar projeto Supabase descartável (`ford-restore-test-YYYYMM`).
+2. Aplicar último dump manual.
+3. Rodar suite de smoke tests (ver `scripts/smoke.sh`, planejado Sprint 2).
+4. Comparar `COUNT(*)` por tabela vs prod; aceitável diff ≤ 24h (drift do dia).
+5. Apagar projeto de teste (custo: ~$0 se executado em < 4h).
+6. Registrar resultado em `forward-docs/runbooks/restore-tests/YYYY-MM.md`.
+
+## 8. Plano de comunicação em incidentes
+
+Se restore for necessário em prod:
+
+| Severidade | SLA de notificação | Canal |
+| ---------- | ------------------ | ----- |
+| Catastrófico (dados corrompidos) | 15 min | Grupo WhatsApp + e-mail Ford |
+| Alto (restore parcial) | 1 h | E-mail Ford + status page |
+| Médio (rollback de migration) | 4 h | E-mail interno |
+
+## 9. Limitações conhecidas (Sprint 1)
+
+- **Sem teste automatizado de restore** (R-04 ampliado): runbook é manual. Sprint 2
+  deve adicionar workflow `.github/workflows/monthly-restore-test.yml`.
+- **Sem replicação cross-region**: Supabase free/Pro não oferece. Em
+  catastrofe regional AWS São Paulo, indisponibilidade > 6h é aceita.
+- **PITR não cobre Edge Functions deployadas**: estas dependem de re-deploy
+  a partir do git (forward-infra/supabase/functions/).
+- **Tamanho atual do DB**: ~50 MB. Estratégias acima são overkill para o
+  tamanho atual, mas escalam para o estimado pós-Sprint 3 (≥ 5 GB).
+
+## 10. Referências
+
+- Supabase backups: <https://supabase.com/docs/guides/platform/backups>
+- pg_dump reference: <https://www.postgresql.org/docs/16/app-pgdump.html>
+- pg_cron: <https://github.com/citusdata/pg_cron>
+- Continuity planning (ANPD/LGPD art. 50): boas práticas de segurança e governança.

--- a/scripts/lgpd-retention-cron.sql
+++ b/scripts/lgpd-retention-cron.sql
@@ -1,0 +1,25 @@
+-- Schedule the LGPD reaper to run daily at 03:00 UTC (midnight in BRT during
+-- DST). Apply this in the Supabase Dashboard or via psql as the postgres role
+-- AFTER migration 013 is applied.
+--
+-- Requires the pg_cron extension. Enable it in Supabase via:
+--     Dashboard > Database > Extensions > pg_cron > Enable
+-- or by running:
+--     CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+-- Idempotent unschedule: remove a prior job with the same name, if any.
+SELECT cron.unschedule('lgpd-anonymize-expired-customers')
+ WHERE EXISTS (
+     SELECT 1 FROM cron.job WHERE jobname = 'lgpd-anonymize-expired-customers'
+ );
+
+-- Schedule the reaper daily at 03:00 UTC.
+SELECT cron.schedule(
+    'lgpd-anonymize-expired-customers',
+    '0 3 * * *',
+    $$ SELECT anonymize_expired_customers(); $$
+);
+
+-- Verify:
+--   SELECT jobid, jobname, schedule, command, active FROM cron.job
+--    WHERE jobname = 'lgpd-anonymize-expired-customers';

--- a/supabase/migrations/013_lgpd_retention_policy.sql
+++ b/supabase/migrations/013_lgpd_retention_policy.sql
@@ -1,0 +1,101 @@
+-- Migration: 013_lgpd_retention_policy
+-- LGPD (Lei 13.709/2018) art. 16: dados pessoais devem ser eliminados apos
+-- o termino do tratamento. This migration implements:
+--   1) An explicit deletion-request marker so customers can opt out.
+--   2) An anonymization function that nullifies PII but preserves the row
+--      (keeps FK integrity for service_events, leads, churn_scores).
+--   3) A reaper function that anonymizes expired rows in bulk; intended to
+--      be invoked by a daily pg_cron job (see scripts/lgpd-retention-cron.sql).
+--   4) An audit_log entry per anonymized customer (non-repudiation).
+
+-- 1) Track explicit deletion requests
+ALTER TABLE customers
+    ADD COLUMN IF NOT EXISTS lgpd_deletion_requested_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN customers.lgpd_deletion_requested_at IS
+    'Set when the customer (or staff on their behalf) requests data deletion. '
+    'After a 30-day cooling-off window the anonymize_expired_customers reaper '
+    'nullifies PII for this row. Audit_log entry is written on anonymization.';
+
+-- 2) Anonymize a single customer
+CREATE OR REPLACE FUNCTION anonymize_customer(target_id UUID, reason TEXT DEFAULT 'lgpd_request')
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    affected INTEGER;
+BEGIN
+    UPDATE customers
+       SET full_name       = '[ANONYMIZED]',
+           cpf             = NULL,
+           birth_date      = NULL,
+           email           = NULL,
+           phone           = NULL,
+           city            = NULL,
+           state           = NULL,
+           opt_in_whatsapp = FALSE,
+           opt_in_email    = FALSE,
+           updated_at      = NOW()
+     WHERE id = target_id
+       AND full_name <> '[ANONYMIZED]';
+    GET DIAGNOSTICS affected = ROW_COUNT;
+
+    IF affected > 0 THEN
+        INSERT INTO audit_log (action, resource_type, resource_id, payload)
+        VALUES (
+            'anonymize',
+            'customer',
+            target_id::TEXT,
+            jsonb_build_object('reason', reason, 'at', NOW())
+        );
+        RETURN TRUE;
+    END IF;
+    RETURN FALSE;
+END;
+$$;
+
+COMMENT ON FUNCTION anonymize_customer(UUID, TEXT) IS
+    'Nullifies PII fields for a single customer and writes an audit_log entry. '
+    'Returns TRUE if a row was actually anonymized. Idempotent: noop if already anonymized.';
+
+-- 3) Bulk reaper: candidates are
+--    (a) explicit deletion requests older than 30 days (cooling-off), OR
+--    (b) records with no LGPD consent ever, older than 12 months.
+CREATE OR REPLACE FUNCTION anonymize_expired_customers()
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    candidate UUID;
+    total     INTEGER := 0;
+BEGIN
+    FOR candidate IN
+        SELECT id FROM customers
+         WHERE full_name <> '[ANONYMIZED]'
+           AND (
+                (lgpd_deletion_requested_at IS NOT NULL
+                 AND lgpd_deletion_requested_at < NOW() - INTERVAL '30 days')
+                OR
+                (lgpd_consent_at IS NULL
+                 AND created_at < NOW() - INTERVAL '12 months')
+           )
+    LOOP
+        IF anonymize_customer(candidate, 'retention_policy') THEN
+            total := total + 1;
+        END IF;
+    END LOOP;
+    RETURN total;
+END;
+$$;
+
+COMMENT ON FUNCTION anonymize_expired_customers() IS
+    'Reaper to be called daily by pg_cron. Returns count of newly anonymized '
+    'customers. See scripts/lgpd-retention-cron.sql for the schedule definition.';
+
+-- Restrict execution to service role / admin only.
+REVOKE EXECUTE ON FUNCTION anonymize_customer(UUID, TEXT) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION anonymize_expired_customers() FROM PUBLIC;


### PR DESCRIPTION
## Resumo

Fecha o **risco R-02** documentado no [SECURITY.md](SECURITY.md) (PR #6): LGPD
retention policy automática + runbook de backup/restore.

## Conteúdo

### 1. Migration 013 — LGPD retention
- `ADD COLUMN customers.lgpd_deletion_requested_at` (nullable timestamp)
- `FUNCTION anonymize_customer(uuid, text)`: nullifies PII, preserva row pra FK integrity, escreve audit_log entry. SECURITY DEFINER, idempotente.
- `FUNCTION anonymize_expired_customers()`: bulk reaper com 2 políticas:
  - (a) explicit deletion request > 30 dias (cooling-off)
  - (b) sem LGPD consent + criado > 12 meses
- `REVOKE EXECUTE FROM PUBLIC` — só service role / admin.

### 2. Cron script
`scripts/lgpd-retention-cron.sql` agenda o reaper via pg_cron diariamente 03:00 UTC.

### 3. BACKUP_RESTORE.md
Runbook completo:
- Backup automático Supabase (PITR 7d/30d)
- pg_dump manual pré-deploy
- Restore via PITR + restore via dump
- Teste mensal de restore (R-04)
- Limitações conhecidas Sprint 1

## Atendimento à LGPD

Migration cobre **art. 16** (eliminação após término do tratamento). Audit_log
mantém trilha de não-repúdio (art. 37).

## Test plan

- [ ] Aplicar migration 013 em projeto Supabase staging
- [ ] Executar `anonymize_customer('<id-teste>')` e verificar:
  - PII zerada (`full_name = '[ANONYMIZED]'`, demais NULL)
  - audit_log entry criada
  - FKs intactas (service_events ainda referenciam o id)
- [ ] Executar `anonymize_expired_customers()` no projeto staging com seed manipulado
- [ ] Habilitar pg_cron + rodar `scripts/lgpd-retention-cron.sql`

🤖 Generated with [Claude Code](https://claude.com/claude-code)